### PR TITLE
Update societies.csv

### DIFF
--- a/datasets/EA/societies.csv
+++ b/datasets/EA/societies.csv
@@ -998,7 +998,7 @@ Ed15b,xd643,Chekiang,wuch1236,Chekiang (Ed15b),Chinese,1936,,,31,120,31,120,Orig
 Ed16,xd644,Cantonese,yuec1235,Cantonese (Ed16),,1940,,,23,113,23,113,Original,
 Ed2,xd645,Lolo,sich1238,Lolo (Ed2),"Yi, Nosu",1940,Yi (AE04),http://ehrafworldcultures.yale.edu/collection?owc=AE04,29,103,29,103,Original,
 Ed3,xd646,Manchu,manc1252,Manchu (Ed3),,1920,Manchu (AG01),http://ehrafworldcultures.yale.edu/collection?owc=AG04,45,126,45,126,Original,
-Ed4,xd647,Miao,nort2747,Miao (Ed4),,1940,Miao (AE05),http://ehrafworldcultures.yale.edu/collection?owc=AE05,26,107,26,107,Original,
+Ed4,xd647,Miao,horn1235,Miao (Ed4),,1940,Miao (AE05),http://ehrafworldcultures.yale.edu/collection?owc=AE05,26,107,26,107,Original,
 Ed5,xd648,Japanese,nucl1643,Japanese (Ed5),,1950,Okayama (AB43),http://ehrafworldcultures.yale.edu/collection?owc=AB43,35,136,35,136,Original,
 Ed6,xd649,Min Chinese,minn1241,Min Chinese (Ed6),,1920,,,24,115,24,115,Original,
 Ac39,xd65,Nyasa,mand1423,Nyasa (Ac39),"Anyassa, Wanyassa",1920,,,-13,35,-13,35,Original,


### PR DESCRIPTION
Changed Glottolog language association and ISO 639-3 code from `hea` to `hrm` based on comment by H. Hammarström: 

> Based on where Ruey worked, language should be `cqd` or `hrm` (they are intelligible, which is why glottolog only has one entry for them).