### PR TITLE
update Ogaden Arabic

### DIFF
--- a/phylogenies/kitchen_et_al2009/taxa.csv
+++ b/phylogenies/kitchen_et_al2009/taxa.csv
@@ -16,7 +16,7 @@ Mehri,mehr1241,,
 Mesmes,mesm1243,,
 Mesqan,mesq1240,,
 Moroccan.Arabic,moro1292,"xd514, xd513","Cd16, Cd15"
-Ogaden.Arabic,ogad1238,,
+Ogaden.Arabic,stan1318,,
 Soddo,sodd1242,,
 Soqotri,soqo1240,,
 Tigre,tigr1270,"xd446, xd444","Ca38, Ca36"


### PR DESCRIPTION
Ogaden Arabic is probably a version of Standard Arabic spoken by someone from the Ogaden region in Ethiopia, rather than a Cushitic language, so replace with the glottocode for Standard Arabic (stan1318)