### PR TITLE
Added mapping for D301_Kare

### DIFF
--- a/phylogenies/grollemund_et_al2015/taxa.csv
+++ b/phylogenies/grollemund_et_al2015/taxa.csv
@@ -180,6 +180,7 @@ D23_Kibira-Kumu_1919,komo1260,xd152,Ae32
 D24_Songola,song1300,xd129,Ae11
 D25_Lega,lega1250,,
 D28_Holoholo,holo1240,,
+D301_Kare,kari1306,,
 D304_Homa_1919,homa1239,,
 D305_Nyanga-li,nyan1303,,
 D308_Bodo2,bodo1272,,


### PR DESCRIPTION
Based on name and classification in https://books.google.de/books?id=PQNHBQAAQBAJ&pg=PT803&lpg=PT803&dq=D301_Kare&source=bl&ots=gtEAiDl29i&sig=ACfU3U0Jjs4qgo_sxU9Gn8AgVKIKO0UwhA&hl=en&sa=X&ved=2ahUKEwjglqatj9vnAhWeSEEAHaxoBvIQ6AEwAXoECAUQAQ#v=onepage&q=D301_Kare&f=false
I think we can map D301_Kare to [Kari](https://glottolog.org/resource/languoid/id/kari1306)