### PR TITLE
Update SCCS society SCCS36 2 Aug 2021

### DIFF
--- a/datasets/SCCS/societies.csv
+++ b/datasets/SCCS/societies.csv
@@ -28,7 +28,7 @@ SCCS31,xd380,Shilluk,shil1265,Shilluk (SCCS31),,1910,Shilluk (FJ23),http://ehraf
 SCCS27,xd383,Masa,masa1322,Masa (SCCS27),Massa,1910,,,10.5,15.5,10.5,15.5,Original,
 SCCS34,xd395,Maasi,masa1300,Masai (SCCS34),Masai,1900,Masai (FL12),http://ehrafworldcultures.yale.edu/collection?owc=FL12,-3.5,36.75,-3.5,36.75,Original,
 SCCS35,xd415,Konso,kons1243,Konso (SCCS35),,1935,,,5.25,37.5,5.25,37.5,Original,
-SCCS36,xd426,Somali,nort3051,Somali (SCCS36),,1900,Somali (MO04),http://ehrafworldcultures.yale.edu/collection?owc=MO04,9,47.25,9,47.25,Original,
+SCCS36,xd426,Somali (Dolbahanta),nort3051,Somali (SCCS36),,1900,Somali (MO04),http://ehrafworldcultures.yale.edu/collection?owc=MO04,9,47.25,9,47.25,Original,
 SCCS33,xd438,Kafa,kafa1242,Kafa (SCCS33),"Kafecho, Kaffa",1905,Kaffa (MP14),http://ehrafworldcultures.yale.edu/collection?owc=MP14,7.27,36.5,7.27,36.5,Original,
 SCCS38,xd445,Blin,bili1260,Bogo (SCCS38),"Bogo, Belen, Bilin",1855,,,15.75,38.75,15.75,38.75,Original,
 SCCS37,xd455,Amhara,amha1245,Amhara (SCCS37),,1953,Amhara (MP05),http://ehrafworldcultures.yale.edu/collection?owc=MP05,12.5,37.75,12.5,37.75,Original,


### PR DESCRIPTION
Updated preferred name for SCCS36 "Somali" to Somali (Dolbhanta)" based on SCCS pinpointing notes, and to differentiate from EA society "Somali (Esa)"